### PR TITLE
Tweaks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,12 @@ services:
      - "15692:15692"
   sqlserver:
     image: masstransit/sqlserver-quartz:latest
+    user: root # required for volume mapping to work
     ports:
       - 1433:1433
-    
+    volumes:
+     - mssql-server-linux-data:/var/opt/mssql/data
+
+
+volumes:
+  mssql-server-linux-data:


### PR DESCRIPTION
I'm opening this here and using as medium to report progress. So far I'm afraid that this chokes in Quartz's logic to handle large batch concurrent triggers which uses too many SQL queries. 

Notes:

* Clustered option isn't the best with single note, but taking the lock shouldn't be the biggest factor here
* For each trigger there can be multiple DB queries to materialize required state (I'll tackle this next on Quartz's side)
* MassTransit parametrizes a job per message, other option would be to use a job without state and push all the state to trigger invocation, then we could optimize Quartz's side not to load job data multiple times if the job key is same (ideally this will change to single query anyway though)

Changes:

* I've moved to scheduler code-config, just to show the option (as an alternative to the stringy version)
* Now using batch size for reading triggers, this allows processing more at one go

I'll examine next how much I can tweak on Quartz's side without breaking the public API.

Without larger batch (the original branch):

````
Total send duration: 0:00:07,6331054
Send message rate: 131,01 (msg/s)
Total consume duration: 0:02:17,0822636
Consume message rate: 7,29 (msg/s)
Concurrent Consumer Count: 4
```

After
```
Total send duration: 0:00:07,8095621
Send message rate: 128,05 (msg/s)
Total consume duration: 0:01:05,0856424
Consume message rate: 15,36 (msg/s)
Concurrent Consumer Count: 6
```

